### PR TITLE
Set serial timeout to positive value

### DIFF
--- a/DynAIkonTrap/sensor.py
+++ b/DynAIkonTrap/sensor.py
@@ -73,7 +73,7 @@ class Sensor:
             SerialException: If the sensor board could not be found
         """
         try:
-            self._ser = Serial(port, baud, timeout=0)
+            self._ser = Serial(port, baud, timeout=0.1)
         except SerialException:
             logger.warning("Sensor board not found on {}, baud {}".format(port, baud))
             self._ser = None


### PR DESCRIPTION
Fixes exceptions due to incomplete lines read from sensor.

timeout = 0 means the readline function can return too soon, before the
line is ended, resulting in half sensor lines, causing exceptions in the
parsing.